### PR TITLE
Create Beatles exemple using discogs data api

### DIFF
--- a/labs/3.BeatlesExample.ipynb
+++ b/labs/3.BeatlesExample.ipynb
@@ -1,0 +1,453 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Criando um banco de dados relacionados aos Beatles usando a api de dados discogs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Objetivo\n",
+    "Este é um exemplo prático utilizando a API de dados do website discogs (https://www.discogs.com/). Para importação de dados foi usado curl no endpoint deste serviço."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Salvando os dados em um json\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Membros\n",
+    "Ao longo da carreira os Beatles tiveram 6 membros, apesar dos mais conhecido foram os 4 que ficaram mais tempo e remanesceram até o final da banda. Os membros ativos considerados ativos foram os que fizeram sucesso ao longo da carreira da banda\n",
+    "- John Lennon (Ativo)\n",
+    "- Paul McCartney (Ativo)\n",
+    "- Richard Starkey (Ringo Starr) (Ativo)\n",
+    "- George Harrison (Ativo)\n",
+    "- Pete Best (Inativo)\n",
+    "- Stuart Sutcliffe (Inativo)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 107,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n",
+      "                                 Dload  Upload   Total   Spent    Left  Speed\n",
+      "100  6546  100  6546    0     0   9311      0 --:--:-- --:--:-- --:--:--  9298\n"
+     ]
+    }
+   ],
+   "source": [
+    "!curl https://api.discogs.com/artists/82730 \\\n",
+    "| python3 -c \"import sys, json; print(json.dumps(json.load(sys.stdin)['members']))\" > beatles_members.json\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Releases\n",
+    "São os lançamentos do Beatles entre LP, Singles e etc. A api de dados tem uma limitação de 500 por página, então para este exemplo teremos uma coleção de 500 itens (dentro de muitos que realmente existem)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 109,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n",
+      "                                 Dload  Upload   Total   Spent    Left  Speed\n",
+      "100  150k  100  150k    0     0   114k      0  0:00:01  0:00:01 --:--:--  114k\n"
+     ]
+    }
+   ],
+   "source": [
+    "!curl https://api.discogs.com/artists/82730/releases?per_page=500 \\\n",
+    "| python3 -c \"import sys, json; print(json.dumps(json.load(sys.stdin)['releases']))\" > beatles_releases.json"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Importanto membros e releases no banco de dados 'beatles'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 105,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2020-08-15T20:18:11.955+0000\tconnected to: mongodb://localhost/\n",
+      "2020-08-15T20:18:11.955+0000\tdropping: beatles.releases\n",
+      "2020-08-15T20:18:11.988+0000\t500 document(s) imported successfully. 0 document(s) failed to import.\n"
+     ]
+    }
+   ],
+   "source": [
+    "!mongoimport --db beatles --collection releases --drop --jsonArray --file $(pwd)/beatles_releases.json"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 98,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2020-08-15T20:16:22.003+0000\tconnected to: mongodb://localhost/\n",
+      "2020-08-15T20:16:22.003+0000\tdropping: beatles.members\n",
+      "2020-08-15T20:16:22.044+0000\t6 document(s) imported successfully. 0 document(s) failed to import.\n"
+     ]
+    }
+   ],
+   "source": [
+    "!mongoimport --db beatles --collection members --drop --jsonArray --file $(pwd)/beatles_members.json"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Usando python para consultas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 81,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Database(MongoClient(host=['localhost:27017'], document_class=dict, tz_aware=False, connect=True), 'beatles')\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pymongo import MongoClient\n",
+    "from pprintpp import pprint\n",
+    "import warnings\n",
+    "warnings.filterwarnings('ignore')\n",
+    "mongoclient = MongoClient('localhost', 27017)\n",
+    "db = mongoclient.beatles\n",
+    "print(db)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Consultas"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exemplo de um documento da colection members"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 111,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'_id': ObjectId('5f38429634396553e8ff6d95'),\n",
+       " 'id': 35301,\n",
+       " 'name': 'Paul McCartney',\n",
+       " 'resource_url': 'https://api.discogs.com/artists/35301',\n",
+       " 'active': True}"
+      ]
+     },
+     "execution_count": 111,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "db.members.find_one({})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Listando todos os membros"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 83,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[\n",
+      "    {'name': 'John Lennon'},\n",
+      "    {'name': 'George Harrison'},\n",
+      "    {'name': 'Richard Starkey'},\n",
+      "    {'name': 'Stuart Sutcliffe'},\n",
+      "    {'name': 'Pete Best'},\n",
+      "    {'name': 'Paul McCartney'},\n",
+      "]\n"
+     ]
+    }
+   ],
+   "source": [
+    "result = db.members.find({}, {\"_id\": 0, \"name\": 1})\n",
+    "pprint(list(result))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Listando apenas os membros ativos"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 114,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[\n",
+      "    {\n",
+      "        'active': True,\n",
+      "        'id': 35301,\n",
+      "        'name': 'Paul McCartney',\n",
+      "        'resource_url': 'https://api.discogs.com/artists/35301',\n",
+      "    },\n",
+      "    {\n",
+      "        'active': True,\n",
+      "        'id': 46481,\n",
+      "        'name': 'John Lennon',\n",
+      "        'resource_url': 'https://api.discogs.com/artists/46481',\n",
+      "    },\n",
+      "    {\n",
+      "        'active': True,\n",
+      "        'id': 298525,\n",
+      "        'name': 'Richard Starkey',\n",
+      "        'resource_url': 'https://api.discogs.com/artists/298525',\n",
+      "    },\n",
+      "    {\n",
+      "        'active': True,\n",
+      "        'id': 243955,\n",
+      "        'name': 'George Harrison',\n",
+      "        'resource_url': 'https://api.discogs.com/artists/243955',\n",
+      "    },\n",
+      "]\n"
+     ]
+    }
+   ],
+   "source": [
+    "result = db.members.find({ \"active\": True }, { \"_id\": 0 })\n",
+    "pprint( list(result) )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exemplo de um documento da collection releases"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 89,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'_id': ObjectId('5f383a67a7b1af3f7542b46f'),\n",
+       " 'id': 9833515,\n",
+       " 'status': 'Accepted',\n",
+       " 'type': 'release',\n",
+       " 'format': 'Acetate, 10\", Mono',\n",
+       " 'label': 'Personal Recording Department',\n",
+       " 'title': 'Hello Little Girl / Till There Was You',\n",
+       " 'resource_url': 'https://api.discogs.com/releases/9833515',\n",
+       " 'role': 'Main',\n",
+       " 'artist': 'The Beatles',\n",
+       " 'year': 1962,\n",
+       " 'thumb': '',\n",
+       " 'stats': {'community': {'in_wantlist': 146, 'in_collection': 8}}}"
+      ]
+     },
+     "execution_count": 89,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "db.releases.find_one({})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Lançamentos do ano de 1963"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 117,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[\n",
+      "    \"All My Loving / Don't Bother Me\",\n",
+      "    \"All My Loving / It Won't Be Long\",\n",
+      "    'All My Loving / Love Me Do',\n",
+      "    'Boys',\n",
+      "    'Ella Te Ama / Quiero Estrechar Tu Mano / La Vi Alla / Seras Mia',\n",
+      "    'From Me To You',\n",
+      "    'From Me To You / I Saw Her Standing There',\n",
+      "    'From Me To You / P. S. I Love You',\n",
+      "    'I Saw Her Standing There',\n",
+      "    'I Saw Her Standing There ',\n",
+      "    'I Saw Her Standing There / Misery',\n",
+      "    'I Want To Hold Your Hand',\n",
+      "    'I Want To Hold Your Hand / Hold Me Tight',\n",
+      "    'I Want To Hold Your Hand / I Saw Her Standing There',\n",
+      "    \"It Won't Be Long\",\n",
+      "    \"Love Me Do / It Won't Be Long\",\n",
+      "    'Love Me Do / Please Please Me',\n",
+      "    'Love Me Do / Twist And Shout',\n",
+      "    'Misery',\n",
+      "    'Muchachos = Boys',\n",
+      "    'My Bonnie',\n",
+      "    'My Bonnie / Ya Ya',\n",
+      "    'Not A Second Time / Hold Me Tight',\n",
+      "    'P.S. I Love You / Chains',\n",
+      "    \"Please Mr Postman / I'll Get You\",\n",
+      "    'Please Please Me',\n",
+      "    'Please Please Me ',\n",
+      "    \"Please Please Me / Baby It's You\",\n",
+      "    'Please Please Me / From Me To You',\n",
+      "    'Por Favor, Yo = Please Please Me',\n",
+      "    'Roll Over Beethoven',\n",
+      "    'Roll Over Beethoven / Devil In Her Heart',\n",
+      "    'Roll Over Beethoven / Please Mister Postman',\n",
+      "    'She Loves You',\n",
+      "    'Sincere Good Wishes For Christmas And The New Year',\n",
+      "    'The Beatles',\n",
+      "    'The Beatles No.1',\n",
+      "    \"The Beatles' Hits\",\n",
+      "    'The Liverpool Sound',\n",
+      "    'Till There Was You',\n",
+      "    'Twist And Shout',\n",
+      "    'What Goes On',\n",
+      "    'With The Beatles',\n",
+      "]\n"
+     ]
+    }
+   ],
+   "source": [
+    "result = db.releases.find({ \"year\": 1963 }).distinct(\"title\")\n",
+    "pprint( list(result) )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Lançamentos feitos entre 1967 e 1969"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 121,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[\n",
+      "    'All You Need Is Love',\n",
+      "    'Bad Boy / Strawberry Fields Forever / Penny Lane / Good Day Sunshine',\n",
+      "    'Christmas Time (Is Here Again)',\n",
+      "    'Hello Goodbye',\n",
+      "    'Hello, Goodbye',\n",
+      "    'Help!',\n",
+      "    'La Banda Del Sargento Pepper',\n",
+      "    'Magical Mystery Tour',\n",
+      "    'Norwegian Wood',\n",
+      "    'Penny Lane',\n",
+      "    \"Sgt. Pepper's Lonely Hearts Club Band\",\n",
+      "    'Strawberry Fields Forever / Penny Lane',\n",
+      "    'The Early Beatles',\n",
+      "    \"This Boy / She's Leaving Home\",\n",
+      "    'Yesterday And Today / Beatles VI',\n",
+      "]\n"
+     ]
+    }
+   ],
+   "source": [
+    "result = db.releases.find({ \"$and\": [ { \"year\": { \"$gte\": 1967 } }, { \"year\": { \"$lte\": 1969 } } ] }).distinct(\"title\")\n",
+    "pprint( list(result) )\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
@matheusmota Boa tarde, Professor!
Eu queria contribuir com um exemplo em que usei a api de dados do discogs para fazer umas consultas envolvendo minha banda favorita.
O massa é que eu fiz (não sei se na base da gambis) usando curl.
A parte que eu extraio o campo que eu quero do curl eu uso python mas daria para usar uma lib chamada jq também (mas teria que instalar).
Fique a vontade para sugerir mais exemplos.

Obrigado!