### PR TITLE
Replace function find().count() with count_documents({})

### DIFF
--- a/labs/pt-br/Exercicio 1.ipynb
+++ b/labs/pt-br/Exercicio 1.ipynb
@@ -139,7 +139,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "db.restaurants.find({}).count()"
+    "db.restaurants.count_documents({})"
    ]
   },
   {


### PR DESCRIPTION
The cursor.count method is deprecated since pymongo 3.7

https://pymongo.readthedocs.io/en/4.0/migrate-to-pymongo4.html#collection-count-and-cursor-count-is-removed